### PR TITLE
Added wrapper for nodejs websocket server.

### DIFF
--- a/src/chord/channels.cljc
+++ b/src/chord/channels.cljc
@@ -9,7 +9,9 @@
             #?(:clj
                [clojure.core.async.impl.protocols :as p]
                :cljs
-               [cljs.core.async.impl.protocols :as p]))
+               [cljs.core.async.impl.protocols :as p])
+
+            [chord.format :as cf])
 
   #?(:cljs (:require-macros [cljs.core.async.macros :refer [go-loop]])))
 
@@ -50,3 +52,20 @@
       (p/close! write-ch)
       (when on-close
         (on-close)))))
+
+(defn- on-close [ws ws-ch]
+  #?(:clj  (http/on-close ws (fn [_] (close! ws-ch)))
+     :cljs (.on ws "close" #(close! ws-ch))))
+
+(defn wrap-websocket [socket {:keys [read-ch write-ch] :as opts} & [cleanup]]
+  (let [{:keys [read-ch write-ch]}
+        (-> {:read-ch (or read-ch (chan))
+             :write-ch (or write-ch (chan))}
+            (cf/wrap-format (dissoc opts :read-ch :write-ch)))]
+
+    (read-from-ws! socket read-ch)
+    (write-to-ws! socket write-ch)
+
+    (let [ws-ch (bidi-ch read-ch write-ch {:on-close cleanup})]
+      (on-close socket ws-ch)
+      ws-ch)))

--- a/src/chord/node.cljs
+++ b/src/chord/node.cljs
@@ -1,0 +1,42 @@
+(ns chord.node
+  (:require [cljs.nodejs :as nodejs]
+            [chord.channels :as channels]
+            [chord.format :as format]))
+
+(defn ws-server [ws-opts {:keys [read-ch write-ch :as chord-opts]} handler]
+  (when-let [ws (nodejs/require "ws")]
+    (let [server (ws.Server. (clj->js ws-opts))]
+      (.on server "connection"
+           (fn [socket request]
+             (let [ws-ch (channels/wrap-websocket socket chord-opts #(.close socket))]
+               (handler ws-ch request))))
+      server)))
+
+(comment
+  "Plain example"
+
+  (defn handler [ws-ch req]
+    (if (authorized? req)
+      (async/put! ws-ch "Welcome!")
+      (do
+        (async/put! ws-ch "Denied!")
+        (async/close! ws-ch)))
+    (async/go
+      (println (async/<! ws-ch))
+      '...))
+
+  (def server (chord.node/ws-server {:port 8080} {:format :edn}) handler)
+
+  "Express Example"
+
+  (def express (nodejs/require "express"))
+  (def https (nodejs/require "https"))
+  (def app (express))
+  '...
+
+  ;; Note: SSL is inherited from the webserver, so using http gives you ws, and
+  ;; https gives you wss.
+  (def server (.createServer https app))
+
+  (def ws-server
+    (chord.node/ws-server server {:format :json} handler)))


### PR DESCRIPTION
I added a `chord.node` namespace with a single function `ws-server` which is a drop in replacement for node's ws package, but the handler gets a chord `bidi-ch` instead of a websocket object. 

A downside to this approach is that the APIs for http-kit and node are different. I think that working smoothly with existing node libraries is more important, but you might disagree.

I've been using this for a toy project and it's worked so far. Not tested in anything production like. 

This reuses the existing http-kit server code and just wraps it in an invocation of `ws.Server`. It's great that adding a new server was basically trivial. 

I also put some example usage in comments in the `chord.node` namespace.